### PR TITLE
Snappier search

### DIFF
--- a/src/Search.js
+++ b/src/Search.js
@@ -18,7 +18,10 @@ class Search extends Component {
 			finishedLoading: false,
 		}
 		this.props.history.listen((location, action) => {
-			this.getQuerry()
+    		// This 100ms delay is necessary for the query to change
+    		setTimeout(function() {
+      			this.getQuerry()
+  			}.bind(this), 100)
 		})
 
 		this.initializeDatabase()

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -92,8 +92,10 @@ class Header extends Component {
 				isLoggedIn: false
  	 	};
     
-    this.props.history.listen((location, action) => {
-			this.getSearchValue()
+    	this.props.history.listen((location, action) => {
+			setTimeout(function() {
+      			this.getSearchValue()
+  			}.bind(this), 100)
 		})
     
 		this.handleSearch = this.handleSearch.bind(this);
@@ -173,7 +175,6 @@ handleSearch(event) {
 		pathname: 'search',
 		search: '?query='+query
 	})
-	window.location.reload()
 };
 
 handleSearchChange(event) {
@@ -217,7 +218,6 @@ handleSavingsClick = (e) => {
 		pathname: 'search',
 		search: '?query=savings&special=true'
 	})
-  	window.location.reload()
 }
 	
     


### PR DESCRIPTION
Now using the location listener instead of reloading the whole page at search request, makes it feel much snappier.